### PR TITLE
Improve validation of `factor` setting, log as error

### DIFF
--- a/src/ghostfolio.js
+++ b/src/ghostfolio.js
@@ -138,8 +138,8 @@ class GhostfolioAPI {
         }
 
         let factor = mapping.factor;
-        if (factor !== undefined && isNaN(factor)) {
-          logger.warn(`The specified factor (${factor}) is not a number`);
+        if (factor !== undefined && !Number.isFinite(factor)) {
+          logger.error(`The specified factor (${factor}) is not a number`);
           continue;
         }
 


### PR DESCRIPTION
As discussed in #93

Works as expected:
<img width="833" height="35" alt="image" src="https://github.com/user-attachments/assets/02d488c4-3eb7-454c-972a-232113c41b2a" />
