### PR TITLE
Improve error resilience

### DIFF
--- a/src/ghostfolio.js
+++ b/src/ghostfolio.js
@@ -138,8 +138,8 @@ class GhostfolioAPI {
         }
 
         let factor = mapping.factor;
-        if (factor !== undefined && isNaN(factor)) {
-          logger.warn(`The specified factor (${factor}) is not a number`);
+        if (factor !== undefined && !Number.isFinite(factor)) {
+          logger.error(`The specified factor (${factor}) is not a number`);
           continue;
         }
 


### PR DESCRIPTION
In `syncAccountBalances()`:
* Removed the top-level try-catch, since we can just let it bubble to the main function, which also logs the error (this avoids logging it twice).
* Wrapped the inner sync-loop in a try-catch so the failed syncing of a single account does not crash the entire sync.
* Throw instead of logging errors/warnings. So no need to `continue`.
* Added a check after the loop that throws if any of the account syncs fail. With the removal of the outer try-catch this means you now get an non-zero exit code when the sync wasn't 100% successful. Meaning you can e.g. discover errors in your config and fix them :-)

In the tests:
* After the above changes, the `should sync balances successfully` didn't, because the mock accounts didn't match the config (the warnings are thrown errors now). So I fixed that.
* Added a negative test case for a partial unsuccessful sync.